### PR TITLE
Generalan setup za OAuth2 autentifikaciju

### DIFF
--- a/IzvorniKod/backend/classmate/src/main/resources/application.properties
+++ b/IzvorniKod/backend/classmate/src/main/resources/application.properties
@@ -9,6 +9,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-spring.security.oauth2.client.registration.google.client-id=YOUR_GOOGLE_CLIENT_ID
-spring.security.oauth2.client.registration.google.client-secret=YOUR_GOOGLE_CLIENT_SECRET
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+
 spring.security.oauth2.client.registration.google.scope=profile, email


### PR DESCRIPTION
# Integracija OAuth2 API Token Ključeva

Ovaj pull request uvodi nove ključeve za pohranu vrijednosti tokena za OAuth2 autentifikaciju.

## Promjene

- Dodani su ključevi za upravljanje Google OAuth2 tokenima:
  - `GOOGLE_CLIENT_ID`
  - `GOOGLE_CLIENT_SECRET`

## Upute za postavljanje
### Opcija 1: Korištenje `.env` Datoteke
1. Kreirajte `.env` datoteku u root direktoriju projekta.
2. Dodajte sljedeće varijable u `.env` datoteku:
   ```plaintext
   GOOGLE_CLIENT_ID=vaš-client-id
   GOOGLE_CLIENT_SECRET=vaš-client-secret
3. Namjestite dependencies i stavite .env u .gitignore 

### Opcija 2: Sistemske varijable
1. Otvorite postavke sistemskih varijabli.
2. U podrucije "System variables" -> "New"
3. Dodajte varijable navedene gore
4. Stisnite "Ok"
